### PR TITLE
Part 9 - Persisting data

### DIFF
--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		D5DC11FD2BC847C5008357A6 /* ding.wav in Resources */ = {isa = PBXBuildFile; fileRef = D5DC11FC2BC847C5008357A6 /* ding.wav */; };
 		D5DC11FF2BC87359008357A6 /* NewScrumSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC11FE2BC87359008357A6 /* NewScrumSheet.swift */; };
 		D5DC12012BC89A6C008357A6 /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12002BC89A6C008357A6 /* History.swift */; };
+		D5DC12032BCAEF11008357A6 /* ScrumStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12022BCAEF11008357A6 /* ScrumStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +79,7 @@
 		D5DC11FC2BC847C5008357A6 /* ding.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = ding.wav; sourceTree = "<group>"; };
 		D5DC11FE2BC87359008357A6 /* NewScrumSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewScrumSheet.swift; sourceTree = "<group>"; };
 		D5DC12002BC89A6C008357A6 /* History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = History.swift; sourceTree = "<group>"; };
+		D5DC12022BCAEF11008357A6 /* ScrumStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -171,6 +173,7 @@
 				D5CC53BF2BC7CE0C007DBD0F /* ScrumTimer.swift */,
 				D5CC53C32BC842A6007DBD0F /* AVPlayer+Ding.swift */,
 				D5DC12002BC89A6C008357A6 /* History.swift */,
+				D5DC12022BCAEF11008357A6 /* ScrumStore.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -339,6 +342,7 @@
 				D5CC53C22BC7D396007DBD0F /* MeetingFooterView.swift in Sources */,
 				D5CC53C02BC7CE0C007DBD0F /* ScrumTimer.swift in Sources */,
 				D5CC53A72BBF4206007DBD0F /* DailyScrum.swift in Sources */,
+				D5DC12032BCAEF11008357A6 /* ScrumStore.swift in Sources */,
 				D5CC53B42BC33554007DBD0F /* DetailView.swift in Sources */,
 				D5CC53BC2BC71C46007DBD0F /* MeetingHeaderView.swift in Sources */,
 				D5CC53B62BC43CFD007DBD0F /* DetailEditView.swift in Sources */,

--- a/Scrumdinger/Models/DailyScrum.swift
+++ b/Scrumdinger/Models/DailyScrum.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct DailyScrum : Identifiable {
+struct DailyScrum : Identifiable, Codable {
     let id: UUID
     var title: String
     var attendees: [Attendee]

--- a/Scrumdinger/Models/DailyScrum.swift
+++ b/Scrumdinger/Models/DailyScrum.swift
@@ -33,7 +33,7 @@ struct DailyScrum : Identifiable {
 }
 
 extension DailyScrum {
-    struct Attendee: Identifiable {
+    struct Attendee: Identifiable, Codable {
         let id: UUID
         var name: String
         

--- a/Scrumdinger/Models/History.swift
+++ b/Scrumdinger/Models/History.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct History: Identifiable {
+struct History: Identifiable, Codable {
     let id: UUID
     let date: Date
     var attendees: [DailyScrum.Attendee]

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -35,6 +35,7 @@ class ScrumStore: ObservableObject {
     func save(scrums: [DailyScrum]) async throws {
         let task = Task {
             let data = try JSONEncoder().encode(scrums)
+            let outfile = try Self.fileURL()
         }
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -5,4 +5,8 @@
 //  Created by ITHelpDec on 13/04/2024.
 //
 
-import Foundation
+import SwiftUI
+
+class ScrumStore: ObservableObject {
+    
+}

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -19,6 +19,8 @@ class ScrumStore: ObservableObject {
     }
     
     func load() async throws {
-        
+        let task = Task {
+            
+        }
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -11,6 +11,9 @@ class ScrumStore: ObservableObject {
     @Published var scrums: [DailyScrum] = []
     
     private static func fileURL() throws -> URL {
-        
+        try FileManager.default.url(for: .documentDirectory,
+                                    in: .userDomainMask,
+                                    appropriateFor: nil,
+                                    create: false)
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -9,4 +9,8 @@ import SwiftUI
 
 class ScrumStore: ObservableObject {
     @Published var scrums: [DailyScrum] = []
+    
+    private static func fileURL() throws -> URL {
+        
+    }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -38,5 +38,6 @@ class ScrumStore: ObservableObject {
             let outfile = try Self.fileURL()
             try data.write(to: outfile)
         }
+        _ = try await task.value
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 class ScrumStore: ObservableObject {
     @Published var scrums: [DailyScrum] = []
     

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -15,5 +15,6 @@ class ScrumStore: ObservableObject {
                                     in: .userDomainMask,
                                     appropriateFor: nil,
                                     create: false)
+        .appendingPathComponent("scrums.data")
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -19,7 +19,7 @@ class ScrumStore: ObservableObject {
     }
     
     func load() async throws {
-        let task = Task {
+        let task = Task<[DailyScrum], Error> {
             
         }
     }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -20,7 +20,7 @@ class ScrumStore: ObservableObject {
     
     func load() async throws {
         let task = Task<[DailyScrum], Error> {
-            
+            let fileURL = try Self.fileURL()
         }
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -27,5 +27,6 @@ class ScrumStore: ObservableObject {
             let DailyScrums = try JSONDecoder().decode([DailyScrum].self, from: data)
             return DailyScrums
         }
+        let scrums = try await task.value
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -8,5 +8,5 @@
 import SwiftUI
 
 class ScrumStore: ObservableObject {
-    
+    @Published var scrums: [DailyScrum] = []
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -17,4 +17,8 @@ class ScrumStore: ObservableObject {
                                     create: false)
         .appendingPathComponent("scrums.data")
     }
+    
+    func load() async throws {
+        
+    }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -36,6 +36,7 @@ class ScrumStore: ObservableObject {
         let task = Task {
             let data = try JSONEncoder().encode(scrums)
             let outfile = try Self.fileURL()
+            try data.write(to: outfile)
         }
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -34,7 +34,7 @@ class ScrumStore: ObservableObject {
     
     func save(scrums: [DailyScrum]) async throws {
         let task = Task {
-            
+            let data = try JSONEncoder().encode(scrums)
         }
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -33,6 +33,8 @@ class ScrumStore: ObservableObject {
     }
     
     func save(scrums: [DailyScrum]) async throws {
-        
+        let task = Task {
+            
+        }
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -29,5 +29,6 @@ class ScrumStore: ObservableObject {
             return DailyScrums
         }
         let scrums = try await task.value
+        self.scrums = scrums
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -1,0 +1,8 @@
+//
+//  ScrumStore.swift
+//  Scrumdinger
+//
+//  Created by ITHelpDec on 13/04/2024.
+//
+
+import Foundation

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -25,6 +25,7 @@ class ScrumStore: ObservableObject {
                 return []
             }
             let DailyScrums = try JSONDecoder().decode([DailyScrum].self, from: data)
+            return DailyScrums
         }
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -31,4 +31,8 @@ class ScrumStore: ObservableObject {
         let scrums = try await task.value
         self.scrums = scrums
     }
+    
+    func save(scrums: [DailyScrum]) async throws {
+        
+    }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -21,6 +21,9 @@ class ScrumStore: ObservableObject {
     func load() async throws {
         let task = Task<[DailyScrum], Error> {
             let fileURL = try Self.fileURL()
+            guard let data = try? Data(contentsOf: fileURL) else {
+                return []
+            }
         }
     }
 }

--- a/Scrumdinger/Models/ScrumStore.swift
+++ b/Scrumdinger/Models/ScrumStore.swift
@@ -24,6 +24,7 @@ class ScrumStore: ObservableObject {
             guard let data = try? Data(contentsOf: fileURL) else {
                 return []
             }
+            let DailyScrums = try JSONDecoder().decode([DailyScrum].self, from: data)
         }
     }
 }

--- a/Scrumdinger/Models/Theme.swift
+++ b/Scrumdinger/Models/Theme.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-enum Theme: String, CaseIterable, Identifiable {
+enum Theme: String, CaseIterable, Identifiable, Codable {
     case bubblegum
     case buttercup
     case indigo

--- a/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/ScrumdingerApp.swift
@@ -14,6 +14,9 @@ struct ScrumdingerApp: App {
     var body: some Scene {
         WindowGroup {
             ScrumsView(scrums: $store.scrums)
+                .task {
+                    
+                }
         }
     }
 }

--- a/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/ScrumdingerApp.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @main
 struct ScrumdingerApp: App {
-    @State private var scrums = DailyScrum.sampleData
+    @StateObject private var store = ScrumStore()
     
     var body: some Scene {
         WindowGroup {

--- a/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/ScrumdingerApp.swift
@@ -15,7 +15,11 @@ struct ScrumdingerApp: App {
         WindowGroup {
             ScrumsView(scrums: $store.scrums)
                 .task {
-                    
+                    do {
+                        try await store.load()
+                    } catch {
+                        fatalError(error.localizedDescription)
+                    }
                 }
         }
     }

--- a/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/ScrumdingerApp.swift
@@ -15,7 +15,11 @@ struct ScrumdingerApp: App {
         WindowGroup {
             ScrumsView(scrums: $store.scrums) {
                 Task {
-                    
+                    do {
+                        try await store.save(scrums: store.scrums)
+                    } catch {
+                        fatalError(error.localizedDescription)
+                    }
                 }
             }
             .task {

--- a/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/ScrumdingerApp.swift
@@ -13,14 +13,18 @@ struct ScrumdingerApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ScrumsView(scrums: $store.scrums)
-                .task {
-                    do {
-                        try await store.load()
-                    } catch {
-                        fatalError(error.localizedDescription)
-                    }
+            ScrumsView(scrums: $store.scrums) {
+                Task {
+                    
                 }
+            }
+            .task {
+                do {
+                    try await store.load()
+                } catch {
+                    fatalError(error.localizedDescription)
+                }
+            }
         }
     }
 }

--- a/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/ScrumdingerApp.swift
@@ -13,7 +13,7 @@ struct ScrumdingerApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ScrumsView(scrums: $scrums)
+            ScrumsView(scrums: $store.scrums)
         }
     }
 }

--- a/Scrumdinger/Views/ScrumsView.swift
+++ b/Scrumdinger/Views/ScrumsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ScrumsView: View {
     @Binding var scrums: [DailyScrum]
+    @Environment(\.scenePhase) private var scenePhase
     @State private var isPresentingNewScrumView = false
     
     var body: some View {

--- a/Scrumdinger/Views/ScrumsView.swift
+++ b/Scrumdinger/Views/ScrumsView.swift
@@ -11,6 +11,7 @@ struct ScrumsView: View {
     @Binding var scrums: [DailyScrum]
     @Environment(\.scenePhase) private var scenePhase
     @State private var isPresentingNewScrumView = false
+    let saveAction: ()->Void
     
     var body: some View {
         NavigationStack {
@@ -37,5 +38,5 @@ struct ScrumsView: View {
 }
 
 #Preview {
-    ScrumsView(scrums: .constant(DailyScrum.sampleData))
+    ScrumsView(scrums: .constant(DailyScrum.sampleData), saveAction: {})
 }

--- a/Scrumdinger/Views/ScrumsView.swift
+++ b/Scrumdinger/Views/ScrumsView.swift
@@ -35,7 +35,7 @@ struct ScrumsView: View {
             NewScrumSheet(scrums: $scrums, isPresentingNewScrumView: $isPresentingNewScrumView)
         }
         .onChange(of: scenePhase) { phase in
-            
+            if (phase == .inactive) { saveAction() }
         }
     }
 }

--- a/Scrumdinger/Views/ScrumsView.swift
+++ b/Scrumdinger/Views/ScrumsView.swift
@@ -34,6 +34,9 @@ struct ScrumsView: View {
         .sheet(isPresented: $isPresentingNewScrumView) {
             NewScrumSheet(scrums: $scrums, isPresentingNewScrumView: $isPresentingNewScrumView)
         }
+        .onChange(of: scenePhase) { phase in
+            
+        }
     }
 }
 

--- a/Scrumdinger/Views/ScrumsView.swift
+++ b/Scrumdinger/Views/ScrumsView.swift
@@ -34,8 +34,8 @@ struct ScrumsView: View {
         .sheet(isPresented: $isPresentingNewScrumView) {
             NewScrumSheet(scrums: $scrums, isPresentingNewScrumView: $isPresentingNewScrumView)
         }
-        .onChange(of: scenePhase) { phase in
-            if (phase == .inactive) { saveAction() }
+        .onChange(of: scenePhase) {
+            if (scenePhase == .inactive) { saveAction() }
         }
     }
 }


### PR DESCRIPTION
Link to tutorial is [here](https://developer.apple.com/tutorials/app-dev-training/persisting-data).

One tweak was suggested for iOS 17, where `.onChange(of:perform:)` with a one-parameter action closure was recently deprecated in favour of either a two- or zero-parameter action closure (credit to [this](https://www.optimistic-closures.com/how-to-fix-onchange-of-perform-deprecated-in-ios-17-0-warnings/) article for tips on adjusting the syntax).

```
onChange(of:perform:)' was deprecated in iOS 17.0: Use `onChange` with a two or zero parameter action closure instead.
```

I'm also beginning to notice a trend where variable / parameter names look to be either identical or similar across different files - I feel like there could have been better naming strategies used to help make variables more easily-distinguishable across various files, and also reduce the risk of naming collisions.

With these changes, we can now close the app without losing our changes - below is a screenshot of a scrum that was saved, following a hard close and re-launch of the app.

<details>
<summary><b>Screenshot</b> - <i>(click here to expand / collapse)</i></summary>

</br>

<img src="https://github.com/ITHelpDec/Scrumdinger/assets/34002836/0999a257-8fa3-4f37-b02d-95132e40b5d5" width=40%>

</details>