### PR TITLE
Part 10 - Handling errors

### DIFF
--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		D5DC11FF2BC87359008357A6 /* NewScrumSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC11FE2BC87359008357A6 /* NewScrumSheet.swift */; };
 		D5DC12012BC89A6C008357A6 /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12002BC89A6C008357A6 /* History.swift */; };
 		D5DC12032BCAEF11008357A6 /* ScrumStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12022BCAEF11008357A6 /* ScrumStore.swift */; };
+		D5DC12052BCC1B52008357A6 /* ErrorWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12042BCC1B52008357A6 /* ErrorWrapper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +81,7 @@
 		D5DC11FE2BC87359008357A6 /* NewScrumSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewScrumSheet.swift; sourceTree = "<group>"; };
 		D5DC12002BC89A6C008357A6 /* History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = History.swift; sourceTree = "<group>"; };
 		D5DC12022BCAEF11008357A6 /* ScrumStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumStore.swift; sourceTree = "<group>"; };
+		D5DC12042BCC1B52008357A6 /* ErrorWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorWrapper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -174,6 +176,7 @@
 				D5CC53C32BC842A6007DBD0F /* AVPlayer+Ding.swift */,
 				D5DC12002BC89A6C008357A6 /* History.swift */,
 				D5DC12022BCAEF11008357A6 /* ScrumStore.swift */,
+				D5DC12042BCC1B52008357A6 /* ErrorWrapper.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -344,6 +347,7 @@
 				D5CC53A72BBF4206007DBD0F /* DailyScrum.swift in Sources */,
 				D5DC12032BCAEF11008357A6 /* ScrumStore.swift in Sources */,
 				D5CC53B42BC33554007DBD0F /* DetailView.swift in Sources */,
+				D5DC12052BCC1B52008357A6 /* ErrorWrapper.swift in Sources */,
 				D5CC53BC2BC71C46007DBD0F /* MeetingHeaderView.swift in Sources */,
 				D5CC53B62BC43CFD007DBD0F /* DetailEditView.swift in Sources */,
 				D5DC11FF2BC87359008357A6 /* NewScrumSheet.swift in Sources */,

--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		D5DC12012BC89A6C008357A6 /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12002BC89A6C008357A6 /* History.swift */; };
 		D5DC12032BCAEF11008357A6 /* ScrumStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12022BCAEF11008357A6 /* ScrumStore.swift */; };
 		D5DC12052BCC1B52008357A6 /* ErrorWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12042BCC1B52008357A6 /* ErrorWrapper.swift */; };
+		D5DC12072BCC1C43008357A6 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12062BCC1C43008357A6 /* ErrorView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +83,7 @@
 		D5DC12002BC89A6C008357A6 /* History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = History.swift; sourceTree = "<group>"; };
 		D5DC12022BCAEF11008357A6 /* ScrumStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumStore.swift; sourceTree = "<group>"; };
 		D5DC12042BCC1B52008357A6 /* ErrorWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorWrapper.swift; sourceTree = "<group>"; };
+		D5DC12062BCC1C43008357A6 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -196,6 +198,7 @@
 				D5CC53BD2BC72345007DBD0F /* ScrumProgressViewStyle.swift */,
 				D5CC53C12BC7D396007DBD0F /* MeetingFooterView.swift */,
 				D5DC11FE2BC87359008357A6 /* NewScrumSheet.swift */,
+				D5DC12062BCC1C43008357A6 /* ErrorView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -343,6 +346,7 @@
 				D5CC53BA2BC5C8BA007DBD0F /* ThemePicker.swift in Sources */,
 				D5CC53BE2BC72345007DBD0F /* ScrumProgressViewStyle.swift in Sources */,
 				D5CC53C22BC7D396007DBD0F /* MeetingFooterView.swift in Sources */,
+				D5DC12072BCC1C43008357A6 /* ErrorView.swift in Sources */,
 				D5CC53C02BC7CE0C007DBD0F /* ScrumTimer.swift in Sources */,
 				D5CC53A72BBF4206007DBD0F /* DailyScrum.swift in Sources */,
 				D5DC12032BCAEF11008357A6 /* ScrumStore.swift in Sources */,

--- a/Scrumdinger/Models/ErrorWrapper.swift
+++ b/Scrumdinger/Models/ErrorWrapper.swift
@@ -11,4 +11,10 @@ struct ErrorWrapper: Identifiable {
     let id: UUID
     let error: Error
     let guidance: String
+    
+    init(id: UUID = UUID(), error: Error, guidance: String) {
+        self.id = id
+        self.error = error
+        self.guidance = guidance
+    }
 }

--- a/Scrumdinger/Models/ErrorWrapper.swift
+++ b/Scrumdinger/Models/ErrorWrapper.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+struct ErrorWrapper: Identifiable {
+    let id: UUID
+}

--- a/Scrumdinger/Models/ErrorWrapper.swift
+++ b/Scrumdinger/Models/ErrorWrapper.swift
@@ -9,4 +9,6 @@ import Foundation
 
 struct ErrorWrapper: Identifiable {
     let id: UUID
+    let error: Error
+    let guidance: String
 }

--- a/Scrumdinger/Models/ErrorWrapper.swift
+++ b/Scrumdinger/Models/ErrorWrapper.swift
@@ -1,0 +1,8 @@
+//
+//  ErrorWrapper.swift
+//  Scrumdinger
+//
+//  Created by ITHelpDec on 14/04/2024.
+//
+
+import Foundation

--- a/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/ScrumdingerApp.swift
@@ -10,6 +10,7 @@ import SwiftUI
 @main
 struct ScrumdingerApp: App {
     @StateObject private var store = ScrumStore()
+    @State private var errorWrapper: ErrorWrapper?
     
     var body: some Scene {
         WindowGroup {

--- a/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/ScrumdingerApp.swift
@@ -19,7 +19,7 @@ struct ScrumdingerApp: App {
                     do {
                         try await store.save(scrums: store.scrums)
                     } catch {
-                        fatalError(error.localizedDescription)
+                        errorWrapper = ErrorWrapper(error: error, guidance: "Try again later.")
                     }
                 }
             }
@@ -27,7 +27,8 @@ struct ScrumdingerApp: App {
                 do {
                     try await store.load()
                 } catch {
-                    fatalError(error.localizedDescription)
+                    errorWrapper = ErrorWrapper(error: error,
+                                                guidance: "Scrumdinger will load sample data and continue")
                 }
             }
         }

--- a/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/ScrumdingerApp.swift
@@ -34,7 +34,7 @@ struct ScrumdingerApp: App {
             .sheet(item: $errorWrapper) {
                 
             } content: { wrapper in
-                
+                ErrorView(errorWrapper: wrapper)
             }
         }
     }

--- a/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/ScrumdingerApp.swift
@@ -31,6 +31,11 @@ struct ScrumdingerApp: App {
                                                 guidance: "Scrumdinger will load sample data and continue")
                 }
             }
+            .sheet(item: $errorWrapper) {
+                
+            } content: { wrapper in
+                
+            }
         }
     }
 }

--- a/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/ScrumdingerApp.swift
@@ -32,7 +32,7 @@ struct ScrumdingerApp: App {
                 }
             }
             .sheet(item: $errorWrapper) {
-                
+                store.scrums = DailyScrum.sampleData
             } content: { wrapper in
                 ErrorView(errorWrapper: wrapper)
             }

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -15,6 +15,8 @@ struct ErrorView: View {
             Text("An error has occurred!")
                 .font(.title)
                 .padding(.bottom)
+            Text(errorWrapper.error.localizedDescription)
+                .font(.headline)
             Spacer()
         }
         .padding()

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -17,6 +17,9 @@ struct ErrorView: View {
                 .padding(.bottom)
             Text(errorWrapper.error.localizedDescription)
                 .font(.headline)
+            Text(errorWrapper.guidance)
+                .font(.caption)
+                .padding(.top)
             Spacer()
         }
         .padding()

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -11,7 +11,11 @@ struct ErrorView: View {
     let errorWrapper: ErrorWrapper
     
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+            Spacer()
+        }
+        .padding()
     }
 }
 

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ErrorView: View {
     let errorWrapper: ErrorWrapper
+    @Environment(\.dismiss) private var dismiss
     
     var body: some View {
         NavigationStack {

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ErrorView: View {
+    let errorWrapper: ErrorWrapper
+    
     var body: some View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
     }

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -16,5 +16,9 @@ struct ErrorView: View {
 }
 
 #Preview {
+    enum SampleError: Error {
+        case errorRequired
+    }
+    
     ErrorView()
 }

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -23,6 +23,8 @@ struct ErrorView: View {
             Spacer()
         }
         .padding()
+        .background(.ultraThinMaterial)
+        .cornerRadius(16)
     }
 }
 

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -29,7 +29,9 @@ struct ErrorView: View {
             .cornerRadius(16)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    
+                    Button("Dismiss") {
+                        dismiss()
+                    }
                 }
             }
         }

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -1,0 +1,18 @@
+//
+//  ErrorView.swift
+//  Scrumdinger
+//
+//  Created by ITHelpDec on 14/04/2024.
+//
+
+import SwiftUI
+
+struct ErrorView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    ErrorView()
+}

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -27,6 +27,11 @@ struct ErrorView: View {
             .padding()
             .background(.ultraThinMaterial)
             .cornerRadius(16)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    
+                }
+            }
         }
     }
 }

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -15,7 +15,7 @@ struct ErrorView: View {
     }
 }
 
-#Preview {
+struct ErrorView_Previews: PreviewProvider {
     enum SampleError: Error {
         case errorRequired
     }
@@ -24,5 +24,7 @@ struct ErrorView: View {
         ErrorWrapper(error: SampleError.errorRequired, guidance: "You can safely ignore this error.")
     }
     
-    ErrorView(errorWrapper: wrapper)
+    static var previews: some View {
+        ErrorView(errorWrapper: wrapper)
+    }
 }

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -12,7 +12,9 @@ struct ErrorView: View {
     
     var body: some View {
         VStack {
-            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+            Text("An error has occurred!")
+                .font(.title)
+                .padding(.bottom)
             Spacer()
         }
         .padding()

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -24,5 +24,5 @@ struct ErrorView: View {
         ErrorWrapper(error: SampleError.errorRequired, guidance: "You can safely ignore this error.")
     }
     
-    ErrorView()
+    ErrorView(errorWrapper: wrapper)
 }

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -11,20 +11,22 @@ struct ErrorView: View {
     let errorWrapper: ErrorWrapper
     
     var body: some View {
-        VStack {
-            Text("An error has occurred!")
-                .font(.title)
-                .padding(.bottom)
-            Text(errorWrapper.error.localizedDescription)
-                .font(.headline)
-            Text(errorWrapper.guidance)
-                .font(.caption)
-                .padding(.top)
-            Spacer()
+        NavigationStack {
+            VStack {
+                Text("An error has occurred!")
+                    .font(.title)
+                    .padding(.bottom)
+                Text(errorWrapper.error.localizedDescription)
+                    .font(.headline)
+                Text(errorWrapper.guidance)
+                    .font(.caption)
+                    .padding(.top)
+                Spacer()
+            }
+            .padding()
+            .background(.ultraThinMaterial)
+            .cornerRadius(16)
         }
-        .padding()
-        .background(.ultraThinMaterial)
-        .cornerRadius(16)
     }
 }
 

--- a/Scrumdinger/Views/ErrorView.swift
+++ b/Scrumdinger/Views/ErrorView.swift
@@ -20,5 +20,9 @@ struct ErrorView: View {
         case errorRequired
     }
     
+    static var wrapper: ErrorWrapper {
+        ErrorWrapper(error: SampleError.errorRequired, guidance: "You can safely ignore this error.")
+    }
+    
     ErrorView()
 }


### PR DESCRIPTION
Link to tutorial is [here](https://developer.apple.com/tutorials/app-dev-training/handling-errors).

Only one tweak was needed to convert the default `#Preview` macro to a struct like in the tutorial (https://github.com/ITHelpDec/Scrumdinger/commit/b497599713179bffd77a6487c7216c44b293bccf).

Below is a screenshot of the ErrorWrapper sheet, after we deliberately corrupted the `scrum.data` file - the sample data was then loaded in its place, as expected.

<details>
<summary><b>Screenshot</b> - <I>(click to expand / collapse)</I></summary>

</br>

<img src="https://github.com/ITHelpDec/Scrumdinger/assets/34002836/d4d86b72-9c7c-4f0b-b47e-ee92a9e887ab" width=40%>

</details>