### PR TITLE
Part 12 - Transcribing speech to text

### DIFF
--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -537,6 +537,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Scrumdinger/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Audio is recorded to transcribe the meeting. Audio recordings are discarded after transcription.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "You can view a text transcription of your meeting in the app.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -567,6 +568,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Scrumdinger/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Audio is recorded to transcribe the meeting. Audio recordings are discarded after transcription.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "You can view a text transcription of your meeting in the app.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -537,6 +537,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Scrumdinger/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "You can view a text transcription of your meeting in the app.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -566,6 +567,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Scrumdinger/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "You can view a text transcription of your meeting in the app.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		D5DC12072BCC1C43008357A6 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12062BCC1C43008357A6 /* ErrorView.swift */; };
 		D5DC12092BCDEE79008357A6 /* MeetingTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12082BCDEE79008357A6 /* MeetingTimerView.swift */; };
 		D5DC120D2BCE71F5008357A6 /* SpeakerArc.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC120C2BCE71F5008357A6 /* SpeakerArc.swift */; };
+		D5DC12102BCEB5F6008357A6 /* SpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC120F2BCEB5F6008357A6 /* SpeechRecognizer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		D5DC12062BCC1C43008357A6 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		D5DC12082BCDEE79008357A6 /* MeetingTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingTimerView.swift; sourceTree = "<group>"; };
 		D5DC120C2BCE71F5008357A6 /* SpeakerArc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerArc.swift; sourceTree = "<group>"; };
+		D5DC120F2BCEB5F6008357A6 /* SpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -183,6 +185,7 @@
 				D5DC12002BC89A6C008357A6 /* History.swift */,
 				D5DC12022BCAEF11008357A6 /* ScrumStore.swift */,
 				D5DC12042BCC1B52008357A6 /* ErrorWrapper.swift */,
+				D5DC120F2BCEB5F6008357A6 /* SpeechRecognizer.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -365,6 +368,7 @@
 				D5DC11FF2BC87359008357A6 /* NewScrumSheet.swift in Sources */,
 				D5CC53AE2BBF6010007DBD0F /* TrailingIconLabelStyle.swift in Sources */,
 				D5CC53A52BBF3F66007DBD0F /* Theme.swift in Sources */,
+				D5DC12102BCEB5F6008357A6 /* SpeechRecognizer.swift in Sources */,
 				D5CC53B22BC32149007DBD0F /* ScrumsView.swift in Sources */,
 				D5CC537C2BBF05FB007DBD0F /* MeetingView.swift in Sources */,
 				D5CC537A2BBF05FB007DBD0F /* ScrumdingerApp.swift in Sources */,

--- a/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		D5DC12092BCDEE79008357A6 /* MeetingTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12082BCDEE79008357A6 /* MeetingTimerView.swift */; };
 		D5DC120D2BCE71F5008357A6 /* SpeakerArc.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC120C2BCE71F5008357A6 /* SpeakerArc.swift */; };
 		D5DC12102BCEB5F6008357A6 /* SpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC120F2BCEB5F6008357A6 /* SpeechRecognizer.swift */; };
+		D5DC12142BCED92B008357A6 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC12132BCED92B008357A6 /* HistoryView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +91,7 @@
 		D5DC12082BCDEE79008357A6 /* MeetingTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingTimerView.swift; sourceTree = "<group>"; };
 		D5DC120C2BCE71F5008357A6 /* SpeakerArc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerArc.swift; sourceTree = "<group>"; };
 		D5DC120F2BCEB5F6008357A6 /* SpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizer.swift; sourceTree = "<group>"; };
+		D5DC12132BCED92B008357A6 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -208,6 +210,7 @@
 				D5DC12062BCC1C43008357A6 /* ErrorView.swift */,
 				D5DC12082BCDEE79008357A6 /* MeetingTimerView.swift */,
 				D5DC120C2BCE71F5008357A6 /* SpeakerArc.swift */,
+				D5DC12132BCED92B008357A6 /* HistoryView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -358,6 +361,7 @@
 				D5DC120D2BCE71F5008357A6 /* SpeakerArc.swift in Sources */,
 				D5DC12072BCC1C43008357A6 /* ErrorView.swift in Sources */,
 				D5CC53C02BC7CE0C007DBD0F /* ScrumTimer.swift in Sources */,
+				D5DC12142BCED92B008357A6 /* HistoryView.swift in Sources */,
 				D5DC12092BCDEE79008357A6 /* MeetingTimerView.swift in Sources */,
 				D5CC53A72BBF4206007DBD0F /* DailyScrum.swift in Sources */,
 				D5DC12032BCAEF11008357A6 /* ScrumStore.swift in Sources */,

--- a/Scrumdinger/Models/History.swift
+++ b/Scrumdinger/Models/History.swift
@@ -11,10 +11,12 @@ struct History: Identifiable, Codable {
     let id: UUID
     let date: Date
     var attendees: [DailyScrum.Attendee]
+    let transcript: String?
     
-    init(id: UUID = UUID(), date: Date = Date(), attendees: [DailyScrum.Attendee]) {
+    init(id: UUID = UUID(), date: Date = Date(), attendees: [DailyScrum.Attendee], transcript: String? = nil) {
         self.id = id
         self.date = date
         self.attendees = attendees
+        self.transcript = transcript
     }
 }

--- a/Scrumdinger/Models/SpeechRecognizer.swift
+++ b/Scrumdinger/Models/SpeechRecognizer.swift
@@ -1,0 +1,187 @@
+//
+//  SpeechRecognizer.swift
+//  Scrumdinger
+//
+//  Created by ITHelpDec on 16/04/2024.
+//
+
+import Foundation
+import AVFoundation
+import Speech
+import SwiftUI
+
+/// A helper for transcribing speech to text using SFSpeechRecognizer and AVAudioEngine.
+actor SpeechRecognizer: ObservableObject {
+    enum RecognizerError: Error {
+        case nilRecognizer
+        case notAuthorizedToRecognize
+        case notPermittedToRecord
+        case recognizerIsUnavailable
+        
+        var message: String {
+            switch self {
+            case .nilRecognizer: return "Can't initialize speech recognizer"
+            case .notAuthorizedToRecognize: return "Not authorized to recognize speech"
+            case .notPermittedToRecord: return "Not permitted to record audio"
+            case .recognizerIsUnavailable: return "Recognizer is unavailable"
+            }
+        }
+    }
+    
+    @MainActor var transcript: String = ""
+    
+    private var audioEngine: AVAudioEngine?
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+    private let recognizer: SFSpeechRecognizer?
+    
+    /**
+     Initializes a new speech recognizer. If this is the first time you've used the class, it
+     requests access to the speech recognizer and the microphone.
+     */
+    init() {
+        recognizer = SFSpeechRecognizer()
+        guard recognizer != nil else {
+            transcribe(RecognizerError.nilRecognizer)
+            return
+        }
+        
+        Task {
+            do {
+                guard await SFSpeechRecognizer.hasAuthorizationToRecognize() else {
+                    throw RecognizerError.notAuthorizedToRecognize
+                }
+                guard await AVAudioSession.sharedInstance().hasPermissionToRecord() else {
+                    throw RecognizerError.notPermittedToRecord
+                }
+            } catch {
+                transcribe(error)
+            }
+        }
+    }
+    
+    @MainActor func startTranscribing() {
+        Task {
+            await transcribe()
+        }
+    }
+    
+    @MainActor func resetTranscript() {
+        Task {
+            await reset()
+        }
+    }
+    
+    @MainActor func stopTranscribing() {
+        Task {
+            await reset()
+        }
+    }
+    
+    /**
+     Begin transcribing audio.
+     
+     Creates a `SFSpeechRecognitionTask` that transcribes speech to text until you call `stopTranscribing()`.
+     The resulting transcription is continuously written to the published `transcript` property.
+     */
+    private func transcribe() {
+        guard let recognizer, recognizer.isAvailable else {
+            self.transcribe(RecognizerError.recognizerIsUnavailable)
+            return
+        }
+        
+        do {
+            let (audioEngine, request) = try Self.prepareEngine()
+            self.audioEngine = audioEngine
+            self.request = request
+            self.task = recognizer.recognitionTask(with: request, resultHandler: { [weak self] result, error in
+                self?.recognitionHandler(audioEngine: audioEngine, result: result, error: error)
+            })
+        } catch {
+            self.reset()
+            self.transcribe(error)
+        }
+    }
+    
+    /// Reset the speech recognizer.
+    private func reset() {
+        task?.cancel()
+        audioEngine?.stop()
+        audioEngine = nil
+        request = nil
+        task = nil
+    }
+    
+    private static func prepareEngine() throws -> (AVAudioEngine, SFSpeechAudioBufferRecognitionRequest) {
+        let audioEngine = AVAudioEngine()
+        
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.playAndRecord, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        let inputNode = audioEngine.inputNode
+        
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { (buffer: AVAudioPCMBuffer, when: AVAudioTime) in
+            request.append(buffer)
+        }
+        audioEngine.prepare()
+        try audioEngine.start()
+        
+        return (audioEngine, request)
+    }
+    
+    nonisolated private func recognitionHandler(audioEngine: AVAudioEngine, result: SFSpeechRecognitionResult?, error: Error?) {
+        let receivedFinalResult = result?.isFinal ?? false
+        let receivedError = error != nil
+        
+        if receivedFinalResult || receivedError {
+            audioEngine.stop()
+            audioEngine.inputNode.removeTap(onBus: 0)
+        }
+        
+        if let result {
+            transcribe(result.bestTranscription.formattedString)
+        }
+    }
+    
+    
+    nonisolated private func transcribe(_ message: String) {
+        Task { @MainActor in
+            transcript = message
+        }
+    }
+    nonisolated private func transcribe(_ error: Error) {
+        var errorMessage = ""
+        if let error = error as? RecognizerError {
+            errorMessage += error.message
+        } else {
+            errorMessage += error.localizedDescription
+        }
+        Task { @MainActor [errorMessage] in
+            transcript = "<< \(errorMessage) >>"
+        }
+    }
+}
+
+extension SFSpeechRecognizer {
+    static func hasAuthorizationToRecognize() async -> Bool {
+        await withCheckedContinuation { continuation in
+            requestAuthorization { status in
+                continuation.resume(returning: status == .authorized)
+            }
+        }
+    }
+}
+
+extension AVAudioSession {
+    func hasPermissionToRecord() async -> Bool {
+        await withCheckedContinuation { continuation in
+            requestRecordPermission { authorized in
+                continuation.resume(returning: authorized)
+            }
+        }
+    }
+}

--- a/Scrumdinger/Views/DetailView.swift
+++ b/Scrumdinger/Views/DetailView.swift
@@ -48,9 +48,11 @@ struct DetailView: View {
                     Label("No meetings yet", systemImage: "calendar.badge.exclamationmark")
                 }
                 ForEach(scrum.history) { history in
-                    HStack {
-                        Image(systemName: "calendar")
-                        Text(history.date, style: .date)
+                    NavigationLink(destination: HistoryView(history: history)) {
+                        HStack {
+                            Image(systemName: "calendar")
+                            Text(history.date, style: .date)
+                        }
                     }
                 }
             }

--- a/Scrumdinger/Views/HistoryView.swift
+++ b/Scrumdinger/Views/HistoryView.swift
@@ -11,7 +11,11 @@ struct HistoryView: View {
     let history: History
     
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ScrollView {
+            VStack(alignment: .leading) {
+                
+            }
+        }
     }
 }
 

--- a/Scrumdinger/Views/HistoryView.swift
+++ b/Scrumdinger/Views/HistoryView.swift
@@ -1,0 +1,20 @@
+//
+//  HistoryView.swift
+//  Scrumdinger
+//
+//  Created by ITHelpDec on 16/04/2024.
+//
+
+import SwiftUI
+
+struct HistoryView: View {
+    let history: History
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    HistoryView()
+}

--- a/Scrumdinger/Views/HistoryView.swift
+++ b/Scrumdinger/Views/HistoryView.swift
@@ -16,7 +16,17 @@ struct HistoryView: View {
 }
 
 struct HistoryViewPreview: PreviewProvider {
+    static var history: History {
+        History(attendees: [
+            DailyScrum.Attendee(name: "Jon"),
+            DailyScrum.Attendee(name: "Darla"),
+            DailyScrum.Attendee(name: "Luis"),
+        ],
+                transcript: "Darla, would you like to start today? " +
+                            "Sure, yesterday I reviewed Luis' PR and met with the design team to finalize the UI...")
+    }
+    
     static var previews: some View {
-        HistoryView()
+        HistoryView(history: history)
     }
 }

--- a/Scrumdinger/Views/HistoryView.swift
+++ b/Scrumdinger/Views/HistoryView.swift
@@ -26,6 +26,8 @@ struct HistoryView: View {
                 }
             }
         }
+        .navigationTitle(Text(history.date, style: .date))
+        .padding()
     }
 }
 

--- a/Scrumdinger/Views/HistoryView.swift
+++ b/Scrumdinger/Views/HistoryView.swift
@@ -13,7 +13,8 @@ struct HistoryView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading) {
-                
+                Divider()
+                    .padding(.bottom)
             }
         }
     }

--- a/Scrumdinger/Views/HistoryView.swift
+++ b/Scrumdinger/Views/HistoryView.swift
@@ -17,8 +17,15 @@ struct HistoryView: View {
                     .padding(.bottom)
                 Text("Attendees")
                     .font(.headline)
+                Text(history.attendeeString)
             }
         }
+    }
+}
+
+extension History {
+    var attendeeString: String {
+        ListFormatter.localizedString(byJoining: attendees.map { $0.name })
     }
 }
 

--- a/Scrumdinger/Views/HistoryView.swift
+++ b/Scrumdinger/Views/HistoryView.swift
@@ -20,6 +20,8 @@ struct HistoryView: View {
                 Text(history.attendeeString)
                 if let transcript = history.transcript {
                     Text("Transcript")
+                        .font(.headline)
+                        .padding(.top)
                     Text(transcript)
                 }
             }

--- a/Scrumdinger/Views/HistoryView.swift
+++ b/Scrumdinger/Views/HistoryView.swift
@@ -15,6 +15,8 @@ struct HistoryView: View {
             VStack(alignment: .leading) {
                 Divider()
                     .padding(.bottom)
+                Text("Attendees")
+                    .font(.headline)
             }
         }
     }

--- a/Scrumdinger/Views/HistoryView.swift
+++ b/Scrumdinger/Views/HistoryView.swift
@@ -18,6 +18,10 @@ struct HistoryView: View {
                 Text("Attendees")
                     .font(.headline)
                 Text(history.attendeeString)
+                if let transcript = history.transcript {
+                    Text("Transcript")
+                    Text(transcript)
+                }
             }
         }
     }

--- a/Scrumdinger/Views/HistoryView.swift
+++ b/Scrumdinger/Views/HistoryView.swift
@@ -15,6 +15,8 @@ struct HistoryView: View {
     }
 }
 
-#Preview {
-    HistoryView()
+struct HistoryViewPreview: PreviewProvider {
+    static var previews: some View {
+        HistoryView()
+    }
 }

--- a/Scrumdinger/Views/MeetingTimerView.swift
+++ b/Scrumdinger/Views/MeetingTimerView.swift
@@ -27,6 +27,7 @@ struct MeetingTimerView: View {
                     Image(systemName: isRecording ? "mic" : "mic.slash")
                         .font(.title)
                         .padding(.top)
+                        .accessibilityLabel(isRecording ? "with transcription" : "without transcription")
                 }
                 .accessibilityElement(children: .combine)
                 .foregroundStyle(theme.accentColour)

--- a/Scrumdinger/Views/MeetingTimerView.swift
+++ b/Scrumdinger/Views/MeetingTimerView.swift
@@ -25,6 +25,8 @@ struct MeetingTimerView: View {
                         .font(.title)
                     Text("is speaking")
                     Image(systemName: isRecording ? "mic" : "mic.slash")
+                        .font(.title)
+                        .padding(.top)
                 }
                 .accessibilityElement(children: .combine)
                 .foregroundStyle(theme.accentColour)

--- a/Scrumdinger/Views/MeetingTimerView.swift
+++ b/Scrumdinger/Views/MeetingTimerView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MeetingTimerView: View {
     let speakers: [ScrumTimer.Speaker]
+    let isRecording: Bool
     let theme: Theme
     
     private var currentSpeaker: String {
@@ -46,6 +47,6 @@ struct MeetingTimerView_Preview: PreviewProvider {
          ScrumTimer.Speaker(name:"Cathy", isCompleted: false)]
     }
     static var previews: some View {
-        MeetingTimerView(speakers: speakers, theme: .yellow)
+        MeetingTimerView(speakers: speakers, isRecording: true, theme: .yellow)
     }
 }

--- a/Scrumdinger/Views/MeetingTimerView.swift
+++ b/Scrumdinger/Views/MeetingTimerView.swift
@@ -24,6 +24,7 @@ struct MeetingTimerView: View {
                     Text(currentSpeaker)
                         .font(.title)
                     Text("is speaking")
+                    Image(systemName: isRecording ? "mic" : "mic.slash")
                 }
                 .accessibilityElement(children: .combine)
                 .foregroundStyle(theme.accentColour)

--- a/Scrumdinger/Views/MeetingView.swift
+++ b/Scrumdinger/Views/MeetingView.swift
@@ -52,6 +52,7 @@ struct MeetingView: View {
     private func endScrum() {
         scrumTimer.stopScrum()
         speechRecogniser.stopTranscribing()
+        isRecording = false
         let newHistory = History(attendees: scrum.attendees)
         scrum.history.insert(newHistory, at: 0)
     }

--- a/Scrumdinger/Views/MeetingView.swift
+++ b/Scrumdinger/Views/MeetingView.swift
@@ -42,6 +42,7 @@ struct MeetingView: View {
             player.seek(to: .zero)
             player.play()
         }
+        speechRecogniser.resetTranscript()
         scrumTimer.startScrum()
     }
     

--- a/Scrumdinger/Views/MeetingView.swift
+++ b/Scrumdinger/Views/MeetingView.swift
@@ -11,6 +11,7 @@ import AVFoundation
 struct MeetingView: View {
     @Binding var scrum: DailyScrum
     @StateObject var scrumTimer = ScrumTimer()
+    @StateObject var speechRecogniser = SpeechRecognizer()
     
     private var player: AVPlayer { AVPlayer.sharedDingPlayer }
 

--- a/Scrumdinger/Views/MeetingView.swift
+++ b/Scrumdinger/Views/MeetingView.swift
@@ -12,6 +12,7 @@ struct MeetingView: View {
     @Binding var scrum: DailyScrum
     @StateObject var scrumTimer = ScrumTimer()
     @StateObject var speechRecogniser = SpeechRecognizer()
+    @State private var isRecording = false
     
     private var player: AVPlayer { AVPlayer.sharedDingPlayer }
 

--- a/Scrumdinger/Views/MeetingView.swift
+++ b/Scrumdinger/Views/MeetingView.swift
@@ -45,6 +45,7 @@ struct MeetingView: View {
         }
         speechRecogniser.resetTranscript()
         speechRecogniser.startTranscribing()
+        isRecording = true
         scrumTimer.startScrum()
     }
     

--- a/Scrumdinger/Views/MeetingView.swift
+++ b/Scrumdinger/Views/MeetingView.swift
@@ -49,6 +49,7 @@ struct MeetingView: View {
     
     private func endScrum() {
         scrumTimer.stopScrum()
+        speechRecogniser.stopTranscribing()
         let newHistory = History(attendees: scrum.attendees)
         scrum.history.insert(newHistory, at: 0)
     }

--- a/Scrumdinger/Views/MeetingView.swift
+++ b/Scrumdinger/Views/MeetingView.swift
@@ -53,7 +53,7 @@ struct MeetingView: View {
         scrumTimer.stopScrum()
         speechRecogniser.stopTranscribing()
         isRecording = false
-        let newHistory = History(attendees: scrum.attendees)
+        let newHistory = History(attendees: scrum.attendees, transcript: speechRecogniser.transcript)
         scrum.history.insert(newHistory, at: 0)
     }
 }

--- a/Scrumdinger/Views/MeetingView.swift
+++ b/Scrumdinger/Views/MeetingView.swift
@@ -22,7 +22,7 @@ struct MeetingView: View {
                 .fill(scrum.theme.mainColour)
             VStack {
                 MeetingHeaderView(secondsElapsed: scrumTimer.secondsElapsed, secondsRemaining: scrumTimer.secondsRemaining, theme: scrum.theme)
-                MeetingTimerView(speakers: scrumTimer.speakers, theme: scrum.theme)
+                MeetingTimerView(speakers: scrumTimer.speakers, isRecording: isRecording, theme: scrum.theme)
                 MeetingFooterView(speakers: scrumTimer.speakers, skipAction: scrumTimer.skipSpeaker)
             }
             .padding()

--- a/Scrumdinger/Views/MeetingView.swift
+++ b/Scrumdinger/Views/MeetingView.swift
@@ -43,6 +43,7 @@ struct MeetingView: View {
             player.play()
         }
         speechRecogniser.resetTranscript()
+        speechRecogniser.startTranscribing()
         scrumTimer.startScrum()
     }
     


### PR DESCRIPTION
Link to tutorial is [here](https://developer.apple.com/tutorials/app-dev-training/transcribing-speech-to-text).

Some simple steps to take advantage of powerful built-in iOS speech recognition functionality.

One function ([`requestRecordPermission(_:)`](https://developer.apple.com/documentation/avfaudio/avaudiosession/1616601-requestrecordpermission))was marked as deprecated...

```
'requestRecordPermission' was deprecated in iOS 17.0: Please use AVAudioApplication requestRecordPermissionWithCompletionHandler
```
, ... so may be worth updating to the non-deprecated version ([`requestRecordPermission(completionHandler:)`](https://developer.apple.com/documentation/avfaudio/avaudioapplication/4144305-requestrecordpermission))